### PR TITLE
Implement bud-06

### DIFF
--- a/api/gin/api.go
+++ b/api/gin/api.go
@@ -57,6 +57,13 @@ func SetupApi(
 		UploadBlob(blobDescriptorRepo, cdnBaseUrl),
 	)
 
+	// bud-06
+	r.HEAD(
+		"/upload",
+		whitelistPkMiddleware(whitelistedPks, log),
+		UploadRequirements(),
+	)
+
 	r.PUT(
 		"/mirror",
 		nostrAuthMiddleware("upload", log),

--- a/api/gin/controllers.go
+++ b/api/gin/controllers.go
@@ -80,7 +80,7 @@ func UploadRequirements() gin.HandlerFunc {
 		}
 
 		contentType := ctx.GetHeader(HeaderContentType)
-		if contentType == "" || mimetype.Lookup(contentType) == nil {
+		if mimetype.Lookup(contentType) == nil {
 			ctx.Header(HeaderUploadMessage, "invalid Content-Type")
 			ctx.AbortWithStatus(http.StatusBadRequest)
 			return

--- a/application/bud_06.go
+++ b/application/bud_06.go
@@ -1,0 +1,12 @@
+package application
+
+import "context"
+
+func UploadRequirements(
+	ctx context.Context,
+	blobHash string,
+	contentType string,
+	contentLength int,
+) error {
+	return nil
+}

--- a/utils/hashing.go
+++ b/utils/hashing.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 )
 
@@ -11,4 +13,17 @@ func Hash(bytes []byte) (string, error) {
 	hashBytes := h.Sum(nil)
 
 	return fmt.Sprintf("%x", hashBytes), err
+}
+
+func IsSHA256(hash string) error {
+	bytes, err := hex.DecodeString(hash)
+	if err != nil {
+		return err
+	}
+
+	if len(bytes) != 32 {
+		return errors.New("length != 32")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add a `HEAD /upload` endpoint that allows a client to query the server if uploading a file with certain properties will be possible. This avoids the need of the client having to call `PUT /upload` to find out if an upload is possible.

Right now there is not much permission logic build so this PR only adds some basic HTTP header checks to see if the request is valid. Permission logic will come in a future PR.

Addresses #7 